### PR TITLE
Update bioSyntax_SETUP.sh

### DIFF
--- a/bioSyntax_SETUP.sh
+++ b/bioSyntax_SETUP.sh
@@ -148,7 +148,7 @@ if  [ "$(uname)" == "Darwin" ]; then
 
 		# APPENDS LESS PIPE TO BASH PROFILE TO ENABLE AUTOMATIC SYNTAX HIGHLIGHTING
 		if ! grep -q "bioSyntax" ~/.bash_profile; then
-			sudo cat ./less/bp_append.txt >> ~/.bash_profile;
+			sudo cat ${BIOSYNTAX}/less/bp_append.txt >> ~/.bash_profile;
 		fi
 
 		# COPIES LESSPIPE SCRIPT AND THEME FILE(S) TO RIGHT PATHS, CHANGES LESSPIPE SCRIPT TO EXECUTABLE AND THE REST TO READ-ONLY

--- a/bioSyntax_SETUP.sh
+++ b/bioSyntax_SETUP.sh
@@ -143,12 +143,12 @@ if  [ "$(uname)" == "Darwin" ]; then
 
 		# SETS/CREATES PATHS & VARIABLES FOR PLACING THEME FILE(S), LESSPIPE SCRIPT AND SYNTAX FILE(S)
 		SOURCE="${BIOSYNTAX}/less/"
-		FPATH=/usr/local/Cellar/source-highlight/3.1.8_7/share/source-highlight/
-		TPATH=/usr/local/Cellar/source-highlight/3.1.8_7/share/source-highlight/
+		FPATH=/usr/local/opt/source-highlight/share/source-highlight/
+		TPATH=/usr/local/opt/source-highlight/share/source-highlight/
 
 		# APPENDS LESS PIPE TO BASH PROFILE TO ENABLE AUTOMATIC SYNTAX HIGHLIGHTING
 		if ! grep -q "bioSyntax" ~/.bash_profile; then
-			sudo cat /bioSyntax/less/bp_append.txt >> ~/.bash_profile;
+			sudo cat ./less/bp_append.txt >> ~/.bash_profile;
 		fi
 
 		# COPIES LESSPIPE SCRIPT AND THEME FILE(S) TO RIGHT PATHS, CHANGES LESSPIPE SCRIPT TO EXECUTABLE AND THE REST TO READ-ONLY


### PR DESCRIPTION
The current source-highlight version is 3.1.8_8 and the script will fail to locate it.

Hard coding software version in the script is not a good idea. Instead, we should use `/usr/local/opt/source-highlight/share/source-highlight/` to always redirect to the latest version.

The `less/bp_append.txt` path is also incorrect, and was fixed.

BTW: it seems zsh is not supported, please correct me if I was wrong.