### PR TITLE
Update makeRelease.sh

### DIFF
--- a/dev/scripts/makeRelease.sh
+++ b/dev/scripts/makeRelease.sh
@@ -8,18 +8,23 @@
 # Must be run from the main biosyntax directory
 #
 
-NAME='biosyntax'
-VERSION='v0.1-alpha'
+NAME='bioSyntax'
+VERSION='0.1.beta4'
 
 
 # Create a .zip file release
 
-zip -r $NAME.$VERSION.zip \
+zip -r ${NAME}-${VERSION}.zip \
+  alt-syntax/ \
   examples/ \
   gedit/ \
   less/ \
   sublime/ \
   vim/ \
-  bioSyntax_SETUP.sh \
+  bioSyntax_INSTALL.sh \
+  bioSyntax_logo.png \
+  bioSyntax_UNINSTALL.sh \
   LICENSE.md \
-  README.md 
+  INSTALL.md \
+  README.md \
+  man.pdf


### PR DESCRIPTION
Hi,
A small update of makeRelease.sh.

The current bioSyntax-0.1.beta4.zip contains a ".git" folder and other .git* stuffs, which is not very good and need to be repacked without them for the Debian package.

It could be useful to convert this script to a more conventional makefile with dist and clean targets for example.