### PR TITLE
Improve VSCode default comment function behavior

### DIFF
--- a/vscode/language-configuration.json
+++ b/vscode/language-configuration.json
@@ -1,9 +1,9 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
+        "lineComment": "#",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        //"blockComment": [ "/*", "*/" ]
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
Currently, any bioSyntax files within VSCode default to having the "Toggle Line Comment" function add a "//" at the beginning of the line, and the "Toggle Block Comment" encloses the selection in "/* ... */".  

This change disables block comments and changes the Toggle Line Comment to use "#" which is much more common in these types of files.